### PR TITLE
fix(docs): add Claude Code signup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Same team structure. Different AI underneath.
 
 **Full instructions:** [docs/QUICKSTART.md](docs/QUICKSTART.md) - Platform-specific prerequisites, troubleshooting, and step-by-step guide.
 
+**New to Claude?** [Get Claude Code](https://claude.com/pricing) - Required for the AI team features.
+
 ### The Essentials
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a link to https://claude.com/pricing in the Quick Start section for users who don't have Claude Code yet.

## Changes

- Added "New to Claude?" link in README.md Quick Start section

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)