### PR TITLE
docs(onboarding): clarify base template is complete without plugins

### DIFF
--- a/.wtfb/ai-harness/CLAUDE.md
+++ b/.wtfb/ai-harness/CLAUDE.md
@@ -245,9 +245,12 @@ Examples:
 
 ---
 
-## Plugin Installation
+## Optional: Marketplace Plugins
 
-Install the appropriate plugin for your project type:
+**The base template is complete.** All 11 agents, 24 skills, and 30 commands work out of the box. You can start writing immediately with `/start-scene`.
+
+For enhanced workflows (showrunner mode, advanced methodology), you can optionally install marketplace plugins:
+
 ```bash
 # Screenplay projects
 /plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting

--- a/README.md
+++ b/README.md
@@ -145,15 +145,17 @@ cd my-screenplay
 # 3. Install dependencies
 npm install
 
-# 4. Start Claude Code and install the plugin
+# 4. Start Claude Code and start writing!
 claude
-/plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting
-
-# 5. Start writing!
 /start-scene Opening confrontation in the bar
 ```
 
-Your AI team is now active. The Story Architect ensures structure. The Dialogue Writer refines voices. The Script Supervisor catches formatting issues. They work together automatically.
+Your AI team is now active. All 11 agents, 24 skills, and 30 commands work out of the box. The Story Architect ensures structure. The Dialogue Writer refines voices. The Script Supervisor catches formatting issues. They work together automatically.
+
+**Optional: Install marketplace plugins** for enhanced workflows:
+```bash
+/plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting
+```
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -192,17 +192,20 @@ code .
 claude
 ```
 
-**Step 6: Install the plugin**
-
-In Claude Code, run:
-```
-/plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting
-```
-
-**Step 7: Start writing!**
+**Step 6: Start writing!**
 
 ```
 /start-scene Opening confrontation in the bar
+```
+
+Your AI team is ready. All 11 agents, 24 skills, and 30 commands work out of the box.
+
+**Optional: Install Marketplace Plugins**
+
+For enhanced workflows (showrunner mode, advanced methodology), you can install plugins:
+
+```
+/plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting
 ```
 
 ---
@@ -264,17 +267,20 @@ code .
 claude
 ```
 
-**Step 6: Install the plugin**
-
-In Claude Code, run:
-```
-/plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting
-```
-
-**Step 7: Start writing!**
+**Step 6: Start writing!**
 
 ```
 /start-scene Opening confrontation in the bar
+```
+
+Your AI team is ready. All 11 agents, 24 skills, and 30 commands work out of the box.
+
+**Optional: Install Marketplace Plugins**
+
+For enhanced workflows (showrunner mode, advanced methodology), you can install plugins:
+
+```
+/plugin install wtfb-screenwriting@github.com/bybren-llc/wtfb-claude-marketplace/plugins/screenwriting
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes onboarding documentation to clarify that the **base template is complete OSS** without marketplace plugins.

### Changes
- **CLAUDE.md**: Rename "Plugin Installation" → "Optional: Marketplace Plugins"
- **QUICKSTART.md**: Change "Step 6: Install the plugin" → "Step 6: Start writing!" (both macOS/Linux and Windows sections)
- **README.md**: Move plugin install from numbered steps to "Optional" section

### Why this matters
When users clone the template, they should understand:
- All 11 agents work out of the box
- All 24 skills are included
- All 30 commands are available
- Plugins are **optional enhancements**, not requirements

### Verification
- [x] Fresh clone shows `"installed": []` in `.wtfb/project.json`
- [x] `/start-scene` works without any plugin installed
- [x] All three docs now clearly indicate plugins are optional
- [x] `npm run validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)