### PR TITLE
chore(release): bump version to v1.4.1

### DIFF
--- a/.wtfb/project.json
+++ b/.wtfb/project.json
@@ -2,10 +2,10 @@
   "$schema": "https://wtfb.io/schemas/project.v1.json",
   "projectType": "screenplay",
   "name": "wtfb-project",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "template": {
     "upstream": "https://github.com/bybren-llc/wtfb-projects-template",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lastSync": null
   },
   "plugins": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wtfb-project",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wtfb-project",
-      "version": "1.3.1",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "cspell": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtfb-project",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "WTFB Creative Project",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump for v1.4.1 release.

### Changes since v1.4.0
- **docs(onboarding)**: Clarify that base template is complete without plugins
- **fix(docs)**: Add Claude Code signup link to Quick Start

### Key highlight
**Plugins are optional.** The base template includes all 11 agents, 24 skills, and 30 commands out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)