### PR TITLE
chore(legal): add ownership notices to agents and skills

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,0 +1,31 @@
+# WTFB Agents
+
+These agents are part of the **Words To Film By™** multi-agent harness.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [Bybren LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The agent architecture, team structure, and multi-agent methodology are intellectual property of Bybren LLC.
+
+## Agents Included
+
+| Agent | Role |
+|-------|------|
+| Story Architect | Structural authority (veto power) |
+| Dialogue Writer | Character voice specialist |
+| Scene Writer | Action and visual description |
+| Continuity Editor | Timeline and consistency |
+| Script Supervisor | Format authority (gate power) |
+| Research Specialist | Fact-checking and accuracy |
+| Story Analyst | Scene-by-scene quality analysis |
+| Standards Reviewer | Industry best practices |
+| Production Coordinator | Exports and delivery |
+| Session Manager | Workflow coordination |
+| Scene Annotator | Notes and development tracking |
+
+For complete documentation, see [/AGENTS.md](/AGENTS.md).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,44 @@
+# WTFB Skills
+
+These skills are part of the **Words To Film By™** craft knowledge system.
+
+## License
+
+**License:** MIT (see [/LICENSE](/LICENSE))
+**Copyright:** © 2026 J. Scott Graham ([@cheddarfox](https://github.com/cheddarfox)) / [Bybren LLC](https://github.com/bybren-llc)
+**Attribution:** Required per [/NOTICE](/NOTICE)
+
+## Intellectual Property
+
+The skill system architecture and craft methodology are intellectual property of Bybren LLC.
+
+## Skills Included
+
+| Skill | Purpose |
+|-------|---------|
+| action-description | Scene description techniques |
+| arc-check | Character arc validation |
+| character-arcs | Arc development frameworks |
+| character-dialogue | Dialogue formatting |
+| character-interview | 80-question character development |
+| continuity-tracking | Consistency systems |
+| dialogue-craft | Dialogue writing techniques |
+| format-export | PDF/FDX/HTML export procedures |
+| fountain-syntax | Fountain format reference |
+| glossary-reference | Industry terminology |
+| logline | Hook/logline writing |
+| page-estimation | Runtime calculation |
+| pitch-worksheet | Pitch development |
+| power-analysis | Conflict dynamics |
+| rewriting-methodology | 6-step rewrite process |
+| scene-analysis | Scene evaluation techniques |
+| scene-headings | Scene heading formatting |
+| story-check | 12 critical story questions |
+| story-structure | Three-act structure |
+| synopsis | One-page synopsis writing |
+| theme-discovery | Personal theme mining |
+| title-page | Title page formatting |
+| transitions | Transition conventions |
+| writers-room | Collaborative pre-production |
+
+For complete documentation, see [/docs/REFERENCE.md](/docs/REFERENCE.md).


### PR DESCRIPTION
## Summary

Adds README.md files to `.claude/agents/` and `.claude/skills/` directories to make ownership and licensing explicit at point of discovery.

### What's Added
- `.claude/agents/README.md` - License, copyright, IP notice, agent list
- `.claude/skills/README.md` - License, copyright, IP notice, skill list

### Why
- Makes MIT license + NOTICE attribution requirement visible where developers look
- Reinforces that methodology/architecture is Bybren LLC intellectual property
- Low maintenance (2 files referencing root LICENSE/NOTICE)

No version bump - housekeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)