### PR TITLE
feat(skills): add harness and provider badges to all skill READMEs

### DIFF
--- a/.claude/skills/action-description/README.md
+++ b/.claude/skills/action-description/README.md
@@ -1,6 +1,7 @@
 # Action Description
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Screenplay action and description writing techniques.
 

--- a/.claude/skills/arc-check/README.md
+++ b/.claude/skills/arc-check/README.md
@@ -1,6 +1,7 @@
 # Arc Check
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Validates character arc development throughout a screenplay.
 

--- a/.claude/skills/character-arcs/README.md
+++ b/.claude/skills/character-arcs/README.md
@@ -1,6 +1,7 @@
 # Character Arcs
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Character arc development frameworks and techniques.
 

--- a/.claude/skills/character-dialogue/README.md
+++ b/.claude/skills/character-dialogue/README.md
@@ -1,6 +1,7 @@
 # Character Dialogue
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Fountain format character and dialogue formatting rules.
 

--- a/.claude/skills/character-interview/README.md
+++ b/.claude/skills/character-interview/README.md
@@ -1,6 +1,7 @@
 # Character Interview
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > The 80-question character interview framework for deep character development.
 

--- a/.claude/skills/continuity-tracking/README.md
+++ b/.claude/skills/continuity-tracking/README.md
@@ -1,6 +1,7 @@
 # Continuity Tracking
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Screenplay continuity tracking systems and templates.
 

--- a/.claude/skills/dialogue-craft/README.md
+++ b/.claude/skills/dialogue-craft/README.md
@@ -1,6 +1,7 @@
 # Dialogue Craft
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Dialogue writing techniques for screenplays.
 

--- a/.claude/skills/format-export/README.md
+++ b/.claude/skills/format-export/README.md
@@ -1,6 +1,7 @@
 # Format Export
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Screenplay export procedures for PDF, FDX, and HTML.
 

--- a/.claude/skills/fountain-syntax/README.md
+++ b/.claude/skills/fountain-syntax/README.md
@@ -1,6 +1,7 @@
 # Fountain Syntax
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Complete Fountain screenplay format syntax reference.
 

--- a/.claude/skills/glossary-reference/README.md
+++ b/.claude/skills/glossary-reference/README.md
@@ -1,6 +1,7 @@
 # Glossary Reference
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Comprehensive film and television industry terminology.
 

--- a/.claude/skills/logline/README.md
+++ b/.claude/skills/logline/README.md
@@ -1,6 +1,7 @@
 # Logline
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Logline (hook) writing techniques for screenplays.
 

--- a/.claude/skills/page-estimation/README.md
+++ b/.claude/skills/page-estimation/README.md
@@ -1,6 +1,7 @@
 # Page Estimation
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Screenplay page count and runtime estimation formulas.
 

--- a/.claude/skills/pitch-worksheet/README.md
+++ b/.claude/skills/pitch-worksheet/README.md
@@ -1,6 +1,7 @@
 # Pitch Worksheet
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Structured pitch development worksheet for screenwriters.
 

--- a/.claude/skills/power-analysis/README.md
+++ b/.claude/skills/power-analysis/README.md
@@ -1,6 +1,7 @@
 # Power Analysis
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Power dynamics analysis for screenplay scenes.
 

--- a/.claude/skills/rewriting-methodology/README.md
+++ b/.claude/skills/rewriting-methodology/README.md
@@ -1,6 +1,7 @@
 # Rewriting Methodology
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > WTFB 6-step screenplay rewriting process.
 

--- a/.claude/skills/scene-analysis/README.md
+++ b/.claude/skills/scene-analysis/README.md
@@ -1,6 +1,7 @@
 # Scene Analysis
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Scene-by-scene analysis techniques for screenplays.
 

--- a/.claude/skills/scene-headings/README.md
+++ b/.claude/skills/scene-headings/README.md
@@ -1,6 +1,7 @@
 # Scene Headings
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Fountain scene heading formatting rules and conventions.
 

--- a/.claude/skills/story-check/README.md
+++ b/.claude/skills/story-check/README.md
@@ -1,6 +1,7 @@
 # Story Check
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > The 12 critical story questions for screenplay evaluation.
 

--- a/.claude/skills/story-structure/README.md
+++ b/.claude/skills/story-structure/README.md
@@ -1,6 +1,7 @@
 # Story Structure
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Three-act screenplay structure with beat placement.
 

--- a/.claude/skills/synopsis/README.md
+++ b/.claude/skills/synopsis/README.md
@@ -1,6 +1,7 @@
 # Synopsis
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > One-page synopsis writing techniques for screenplays.
 

--- a/.claude/skills/theme-discovery/README.md
+++ b/.claude/skills/theme-discovery/README.md
@@ -1,6 +1,7 @@
 # Theme Discovery
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Personal theme mining exercises for screenwriters.
 

--- a/.claude/skills/title-page/README.md
+++ b/.claude/skills/title-page/README.md
@@ -1,6 +1,7 @@
 # Title Page
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Fountain title page formatting and metadata setup.
 

--- a/.claude/skills/transitions/README.md
+++ b/.claude/skills/transitions/README.md
@@ -1,6 +1,7 @@
 # Transitions
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > Screenplay transition formatting and conventions.
 

--- a/.claude/skills/writers-room/README.md
+++ b/.claude/skills/writers-room/README.md
@@ -1,6 +1,7 @@
 # Writers Room
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
 
 > 6-agent collaborative pre-production session.
 

--- a/.gemini/skills/action-description/README.md
+++ b/.gemini/skills/action-description/README.md
@@ -1,6 +1,8 @@
 # Action Description
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Screenplay action and description writing techniques.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [fountain-syntax](../fountain-syntax/) - Complete Fountain format reference
 - [scene-headings](../scene-headings/) - Scene heading formatting rules
 - [transitions](../transitions/) - Transition formatting conventions
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/arc-check/README.md
+++ b/.gemini/skills/arc-check/README.md
@@ -1,6 +1,8 @@
 # Arc Check
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Validates character arc development throughout a screenplay.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [character-arcs](../character-arcs/) - Arc development frameworks
 - [character-interview](../character-interview/) - 80-question interview framework
 - [dialogue-craft](../dialogue-craft/) - Dialogue writing techniques
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/character-arcs/README.md
+++ b/.gemini/skills/character-arcs/README.md
@@ -1,6 +1,8 @@
 # Character Arcs
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Character arc development frameworks and techniques.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [arc-check](../arc-check/) - Character arc validation
 - [character-interview](../character-interview/) - 80-question interview framework
 - [dialogue-craft](../dialogue-craft/) - Dialogue writing techniques
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/character-dialogue/README.md
+++ b/.gemini/skills/character-dialogue/README.md
@@ -1,6 +1,8 @@
 # Character Dialogue
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Fountain format character and dialogue formatting rules.
 
@@ -43,6 +45,13 @@ Extracted from skill description:
 - [fountain-syntax](../fountain-syntax/) - Complete Fountain format reference
 - [action-description](../action-description/) - Action writing techniques
 - [title-page](../title-page/) - Title page formatting
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/character-interview/README.md
+++ b/.gemini/skills/character-interview/README.md
@@ -1,6 +1,8 @@
 # Character Interview
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > The 80-question character interview framework for deep character development.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [character-arcs](../character-arcs/) - Arc development frameworks
 - [arc-check](../arc-check/) - Character arc validation
 - [dialogue-craft](../dialogue-craft/) - Dialogue writing techniques
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/continuity-tracking/README.md
+++ b/.gemini/skills/continuity-tracking/README.md
@@ -1,6 +1,8 @@
 # Continuity Tracking
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Screenplay continuity tracking systems and templates.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [rewriting-methodology](../rewriting-methodology/) - 6-step rewrite process
 - [page-estimation](../page-estimation/) - Page count calculation
 - [format-export](../format-export/) - Export procedures
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/dialogue-craft/README.md
+++ b/.gemini/skills/dialogue-craft/README.md
@@ -1,6 +1,8 @@
 # Dialogue Craft
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Dialogue writing techniques for screenplays.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [character-arcs](../character-arcs/) - Arc development frameworks
 - [character-interview](../character-interview/) - 80-question interview framework
 - [arc-check](../arc-check/) - Character arc validation
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/format-export/README.md
+++ b/.gemini/skills/format-export/README.md
@@ -1,6 +1,8 @@
 # Format Export
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Screenplay export procedures for PDF, FDX, and HTML.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [continuity-tracking](../continuity-tracking/) - Consistency systems
 - [page-estimation](../page-estimation/) - Page count calculation
 - [rewriting-methodology](../rewriting-methodology/) - 6-step rewrite process
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/fountain-syntax/README.md
+++ b/.gemini/skills/fountain-syntax/README.md
@@ -1,6 +1,8 @@
 # Fountain Syntax
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Complete Fountain screenplay format syntax reference.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [scene-headings](../scene-headings/) - Scene heading formatting rules
 - [character-dialogue](../character-dialogue/) - Character and dialogue formatting
 - [title-page](../title-page/) - Title page formatting
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/glossary-reference/README.md
+++ b/.gemini/skills/glossary-reference/README.md
@@ -1,6 +1,8 @@
 # Glossary Reference
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Comprehensive film and television industry terminology.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [format-export](../format-export/) - Export procedures
 - [page-estimation](../page-estimation/) - Page count calculation
 - [rewriting-methodology](../rewriting-methodology/) - 6-step rewrite process
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/logline/README.md
+++ b/.gemini/skills/logline/README.md
@@ -1,6 +1,8 @@
 # Logline
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Logline (hook) writing techniques for screenplays.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [pitch-worksheet](../pitch-worksheet/) - Pitch development framework
 - [synopsis](../synopsis/) - One-page synopsis writing
 - [theme-discovery](../theme-discovery/) - Personal theme mining
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/page-estimation/README.md
+++ b/.gemini/skills/page-estimation/README.md
@@ -1,6 +1,8 @@
 # Page Estimation
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Screenplay page count and runtime estimation formulas.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [format-export](../format-export/) - Export procedures
 - [continuity-tracking](../continuity-tracking/) - Consistency systems
 - [rewriting-methodology](../rewriting-methodology/) - 6-step rewrite process
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/pitch-worksheet/README.md
+++ b/.gemini/skills/pitch-worksheet/README.md
@@ -1,6 +1,8 @@
 # Pitch Worksheet
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Structured pitch development worksheet for screenwriters.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [logline](../logline/) - Logline writing techniques
 - [synopsis](../synopsis/) - One-page synopsis writing
 - [theme-discovery](../theme-discovery/) - Personal theme mining
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/power-analysis/README.md
+++ b/.gemini/skills/power-analysis/README.md
@@ -1,6 +1,8 @@
 # Power Analysis
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Power dynamics analysis for screenplay scenes.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [scene-analysis](../scene-analysis/) - Scene evaluation techniques
 - [story-check](../story-check/) - 12 critical story questions
 - [story-structure](../story-structure/) - Three-act structure framework
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/rewriting-methodology/README.md
+++ b/.gemini/skills/rewriting-methodology/README.md
@@ -1,6 +1,8 @@
 # Rewriting Methodology
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > WTFB 6-step screenplay rewriting process.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [continuity-tracking](../continuity-tracking/) - Consistency systems
 - [page-estimation](../page-estimation/) - Page count calculation
 - [format-export](../format-export/) - Export procedures
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/scene-analysis/README.md
+++ b/.gemini/skills/scene-analysis/README.md
@@ -1,6 +1,8 @@
 # Scene Analysis
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Scene-by-scene analysis techniques for screenplays.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [power-analysis](../power-analysis/) - Conflict dynamics analysis
 - [story-structure](../story-structure/) - Three-act structure framework
 - [story-check](../story-check/) - 12 critical story questions
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/scene-headings/README.md
+++ b/.gemini/skills/scene-headings/README.md
@@ -1,6 +1,8 @@
 # Scene Headings
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Fountain scene heading formatting rules and conventions.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [fountain-syntax](../fountain-syntax/) - Complete Fountain format reference
 - [action-description](../action-description/) - Action writing techniques
 - [transitions](../transitions/) - Transition formatting conventions
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/story-check/README.md
+++ b/.gemini/skills/story-check/README.md
@@ -1,6 +1,8 @@
 # Story Check
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > The 12 critical story questions for screenplay evaluation.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [story-structure](../story-structure/) - Three-act structure framework
 - [scene-analysis](../scene-analysis/) - Scene evaluation techniques
 - [power-analysis](../power-analysis/) - Conflict dynamics analysis
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/story-structure/README.md
+++ b/.gemini/skills/story-structure/README.md
@@ -1,6 +1,8 @@
 # Story Structure
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Three-act screenplay structure with beat placement.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [story-check](../story-check/) - 12 critical story questions
 - [scene-analysis](../scene-analysis/) - Scene evaluation techniques
 - [power-analysis](../power-analysis/) - Conflict dynamics analysis
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/synopsis/README.md
+++ b/.gemini/skills/synopsis/README.md
@@ -1,6 +1,8 @@
 # Synopsis
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > One-page synopsis writing techniques for screenplays.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [logline](../logline/) - Logline writing techniques
 - [pitch-worksheet](../pitch-worksheet/) - Pitch development framework
 - [theme-discovery](../theme-discovery/) - Personal theme mining
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/theme-discovery/README.md
+++ b/.gemini/skills/theme-discovery/README.md
@@ -1,6 +1,8 @@
 # Theme Discovery
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Personal theme mining exercises for screenwriters.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [logline](../logline/) - Logline writing techniques
 - [pitch-worksheet](../pitch-worksheet/) - Pitch development framework
 - [writers-room](../writers-room/) - Collaborative pre-production
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/title-page/README.md
+++ b/.gemini/skills/title-page/README.md
@@ -1,6 +1,8 @@
 # Title Page
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Fountain title page formatting and metadata setup.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [fountain-syntax](../fountain-syntax/) - Complete Fountain format reference
 - [character-dialogue](../character-dialogue/) - Character and dialogue formatting
 - [scene-headings](../scene-headings/) - Scene heading formatting rules
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/transitions/README.md
+++ b/.gemini/skills/transitions/README.md
@@ -1,6 +1,8 @@
 # Transitions
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > Screenplay transition formatting and conventions.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [fountain-syntax](../fountain-syntax/) - Complete Fountain format reference
 - [scene-headings](../scene-headings/) - Scene heading formatting rules
 - [action-description](../action-description/) - Action writing techniques
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 

--- a/.gemini/skills/writers-room/README.md
+++ b/.gemini/skills/writers-room/README.md
@@ -1,6 +1,8 @@
 # Writers Room
 
 ![Status](https://img.shields.io/badge/status-production-green)
+![Harness](https://img.shields.io/badge/harness-v1.5-blue)
+![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
 
 > 6-agent collaborative pre-production session.
 
@@ -41,6 +43,13 @@ Extracted from skill description:
 - [theme-discovery](../theme-discovery/) - Personal theme mining
 - [pitch-worksheet](../pitch-worksheet/) - Pitch development framework
 - [logline](../logline/) - Logline writing techniques
+
+## Provider Compatibility
+
+| Provider | Status |
+|----------|--------|
+| Gemini CLI | ✅ Native |
+| Claude Code | ✅ Equivalent skill in `.claude/skills/` |
 
 ## Quality Checklist
 


### PR DESCRIPTION
## Summary

Implements team badge pattern recommendations for all 48 skill READMEs.

Closes #11

## Changes

### Claude Skills (24 files)
```markdown
![Status](https://img.shields.io/badge/status-production-green)
![Harness](https://img.shields.io/badge/harness-v1.5-blue)
```

### Gemini Skills (24 files)
```markdown
![Status](https://img.shields.io/badge/status-production-green)
![Harness](https://img.shields.io/badge/harness-v1.5-blue)
![Provider](https://img.shields.io/badge/provider-Gemini_CLI-orange)
```

Plus Provider Compatibility table:
| Provider | Status |
|----------|--------|
| Gemini CLI | ✅ Native |
| Claude Code | ✅ Equivalent skill in `.claude/skills/` |

## Test plan

- [x] `npm run validate` passes (0 errors, 2 pre-existing warnings)
- [x] Verified badges render correctly
- [x] All 48 files updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)