### PR TITLE
feat(command): add /init-readme for auto-populating project README

### DIFF
--- a/.claude/commands/init-readme.md
+++ b/.claude/commands/init-readme.md
@@ -1,0 +1,129 @@
+---
+description: Initialize project README from IMDb-style template.
+---
+
+# /init-readme
+
+Initialize the project README from the IMDb-style template.
+
+## Arguments
+- `[--title <title>]` - Optional: Override project title (defaults to `.wtfb/project.json` name)
+- `[--type <type>]` - Optional: Override project type (screenplay|novel|film-production)
+- `[--force]` - Overwrite even if README appears customized
+- `[--dry-run]` - Show what would be generated without writing
+
+## Workflow
+
+### Step 1: Check Current State
+
+Look for the marker `<!-- wtfb:template-readme -->` in README.md.
+
+**Decision tree:**
+- README.md doesn't exist → proceed
+- README.md has marker → proceed (safe to overwrite)
+- README.md exists without marker → skip (unless `--force`)
+
+If skipping:
+```
+ℹ️ README.md appears to be customized - leaving it unchanged.
+   Use --force to replace it anyway.
+```
+
+### Step 2: Run CLI Command
+
+Execute the deterministic CLI:
+```bash
+npx wtfb init-readme [--title "..."] [--type ...] [--force] [--dry-run]
+```
+
+The CLI will:
+1. Read project info from `.wtfb/project.json` (flags override if provided)
+2. Read `templates/readme-imdb-style.md`
+3. Substitute placeholders:
+   - `# [Project Title] (Year)` → `# {Title} ({Year})`
+   - `[Project Type]` → display label (Screenplay, Novel, Film Production)
+4. Remove the template marker from output
+5. Write to README.md
+
+### Step 3: Confirm Result
+
+**On success (generated):**
+```
+✅ README.md created!
+
+  # [Project Title] (2026)
+  **[Type]** | **[Genre]** | **[Runtime]**
+
+Fill in the remaining placeholders:
+  - Logline and synopsis
+  - Character and crew details
+  - Technical specifications
+```
+
+**On skip (customized):**
+```
+ℹ️ README.md appears to be customized - leaving it unchanged.
+```
+
+**On force overwrite:**
+```
+✅ README.md regenerated (--force)
+
+  # [Project Title] (2026)
+  ...
+```
+
+## Type Display Mapping
+
+| Internal Token | Display Label |
+|----------------|---------------|
+| `screenplay` | Screenplay |
+| `novel` | Novel |
+| `film-production` | Film Production |
+
+## Exit Codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Success OR skipped (customized README) |
+| `1` | Error (template not found, write failed, etc.) |
+
+"Skipped" is informational, not an error.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Template not found | Missing `templates/readme-imdb-style.md` | Restore from template repo |
+| Project config missing | No `.wtfb/project.json` | Run `npm run init` first |
+| Write failed | Permission or disk issue | Check file system |
+
+## Example Usage
+
+### Basic (uses project.json values)
+```
+/init-readme
+```
+
+### With title override
+```
+/init-readme --title "My Amazing Screenplay"
+```
+
+### Force regeneration
+```
+/init-readme --force
+```
+
+### Preview without writing
+```
+/init-readme --dry-run
+```
+
+## Success Criteria
+- [ ] CLI command executed successfully
+- [ ] README.md contains project title and year
+- [ ] Project type shows human-friendly label
+- [ ] Template marker removed from output
+- [ ] User-modified README not overwritten (without --force)
+- [ ] All other placeholders remain for user to fill in

--- a/.claude/commands/start-project.md
+++ b/.claude/commands/start-project.md
@@ -73,6 +73,7 @@ Just type a number or describe what you have!
      - `exports/pdf/`, `exports/fdx/`, `exports/html/`
      - `patterns/`
    - Run `npm install` silently
+   - Run `npx wtfb init-readme --title "[title]"` to generate project README
 
 Display completion:
 ```
@@ -80,6 +81,7 @@ Your workspace is ready!
 
 Created:
   [title].fountain     Your screenplay with title page
+  README.md            Project info page (IMDb style)
   CLAUDE.md            AI assistant instructions
   package.json         Validation scripts (installed)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- wtfb:template-readme -->
 # WTFB Projects Template
 
 <p align="center">

--- a/docs/cli-init-readme-implementation.js
+++ b/docs/cli-init-readme-implementation.js
@@ -1,0 +1,206 @@
+/**
+ * init-readme command implementation for @wtfb/cli
+ *
+ * Add this to the wtfb-packages repo at:
+ * packages/cli/src/commands/init-readme.js (or equivalent)
+ *
+ * Then register in the CLI command index.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATE_MARKER = '<!-- wtfb:template-readme -->';
+const TEMPLATE_PATH = 'templates/readme-imdb-style.md';
+const PROJECT_CONFIG_PATH = '.wtfb/project.json';
+const README_PATH = 'README.md';
+
+// Type display mapping
+const TYPE_LABELS = {
+  'screenplay': 'Screenplay',
+  'novel': 'Novel',
+  'film-production': 'Film Production'
+};
+
+/**
+ * Convert hyphenated string to Title Case
+ * "my-awesome-project" -> "My Awesome Project"
+ */
+function toTitleCase(str) {
+  return str
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/**
+ * Check if README has the template marker
+ */
+function hasTemplateMarker(readmePath) {
+  if (!fs.existsSync(readmePath)) {
+    return false; // No README means safe to create
+  }
+  const content = fs.readFileSync(readmePath, 'utf8');
+  return content.includes(TEMPLATE_MARKER);
+}
+
+/**
+ * Read project configuration
+ */
+function readProjectConfig() {
+  if (!fs.existsSync(PROJECT_CONFIG_PATH)) {
+    return null;
+  }
+  const content = fs.readFileSync(PROJECT_CONFIG_PATH, 'utf8');
+  return JSON.parse(content);
+}
+
+/**
+ * Generate README content from template
+ */
+function generateReadme(title, type, year) {
+  if (!fs.existsSync(TEMPLATE_PATH)) {
+    throw new Error(`Template not found: ${TEMPLATE_PATH}`);
+  }
+
+  let content = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+
+  // Get display label for type
+  const typeLabel = TYPE_LABELS[type] || type;
+
+  // Replace exact header pattern only (first line with title placeholder)
+  content = content.replace(
+    /^# \[Project Title\] \(Year\)/m,
+    `# ${title} (${year})`
+  );
+
+  // Replace project type placeholders
+  content = content.replace(/\[Project Type\]/g, typeLabel);
+
+  // Remove template marker from output (marker lifecycle contract)
+  content = content.replace(TEMPLATE_MARKER + '\n', '');
+  content = content.replace(TEMPLATE_MARKER, '');
+
+  return content;
+}
+
+/**
+ * Main command handler
+ */
+async function initReadme(options = {}) {
+  const { title: titleOverride, type: typeOverride, force, dryRun } = options;
+
+  // Check if safe to proceed
+  const readmeExists = fs.existsSync(README_PATH);
+  const hasMarker = hasTemplateMarker(README_PATH);
+
+  if (readmeExists && !hasMarker && !force) {
+    console.log('ℹ️  README.md appears to be customized - leaving it unchanged.');
+    console.log('   Use --force to replace it anyway.');
+    return { status: 'skipped', reason: 'customized' };
+  }
+
+  // Get project info
+  const projectConfig = readProjectConfig();
+
+  let projectName, projectType;
+
+  if (titleOverride) {
+    projectName = titleOverride;
+  } else if (projectConfig?.name) {
+    projectName = toTitleCase(projectConfig.name);
+  } else {
+    throw new Error('No project name found. Use --title or run init first.');
+  }
+
+  if (typeOverride) {
+    if (!TYPE_LABELS[typeOverride]) {
+      throw new Error(`Invalid type: ${typeOverride}. Use: screenplay, novel, or film-production`);
+    }
+    projectType = typeOverride;
+  } else if (projectConfig?.projectType) {
+    projectType = projectConfig.projectType;
+  } else {
+    projectType = 'screenplay'; // Default
+  }
+
+  const currentYear = new Date().getFullYear();
+
+  // Generate content
+  const readmeContent = generateReadme(projectName, projectType, currentYear);
+
+  if (dryRun) {
+    console.log('--- DRY RUN: Would generate ---');
+    console.log(readmeContent.substring(0, 500) + '...');
+    console.log('-------------------------------');
+    return { status: 'dry-run', content: readmeContent };
+  }
+
+  // Write README
+  fs.writeFileSync(README_PATH, readmeContent, 'utf8');
+
+  const action = force && readmeExists && !hasMarker ? 'forced overwrite' : 'generated';
+  console.log(`✅ README.md ${action}!`);
+  console.log('');
+  console.log(`  # ${projectName} (${currentYear})`);
+  console.log(`  **${TYPE_LABELS[projectType]}** | **[Genre]** | **[Runtime]**`);
+  console.log('');
+  console.log('Fill in the remaining placeholders:');
+  console.log('  - Logline and synopsis');
+  console.log('  - Character and crew details');
+
+  return { status: action, title: projectName, type: projectType, year: currentYear };
+}
+
+// CLI argument parsing (adapt to your CLI framework)
+function parseArgs(args) {
+  const options = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--title' && args[i + 1]) {
+      options.title = args[++i];
+    } else if (arg === '--type' && args[i + 1]) {
+      options.type = args[++i];
+    } else if (arg === '--force') {
+      options.force = true;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    }
+  }
+
+  return options;
+}
+
+// Export for CLI integration
+module.exports = {
+  command: 'init-readme',
+  description: 'Initialize project README from IMDb-style template',
+  options: [
+    { flags: '--title <title>', description: 'Override project title' },
+    { flags: '--type <type>', description: 'Override project type (screenplay|novel|film-production)' },
+    { flags: '--force', description: 'Overwrite even if README is customized' },
+    { flags: '--dry-run', description: 'Show what would be generated without writing' }
+  ],
+  handler: async (options) => {
+    try {
+      await initReadme(options);
+      process.exit(0);
+    } catch (error) {
+      console.error(`❌ Error: ${error.message}`);
+      process.exit(1);
+    }
+  }
+};
+
+// Direct execution support
+if (require.main === module) {
+  const options = parseArgs(process.argv.slice(2));
+  initReadme(options)
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(`❌ Error: ${err.message}`);
+      process.exit(1);
+    });
+}

--- a/scripts/init-project.ps1
+++ b/scripts/init-project.ps1
@@ -530,6 +530,14 @@ foreach ($dir in $placeholderDirs) {
     if (-not (Test-Path $gitkeep)) { New-Item -ItemType File -Path $gitkeep -Force | Out-Null }
 }
 
+# Generate project README from IMDb template
+Write-Host "Generating project README..."
+try {
+    npx wtfb init-readme --title $ProjectTitle --type $ProjectType
+} catch {
+    Write-Yellow "  README generation failed"
+}
+
 Write-Host ""
 Write-Green "========================================"
 Write-Green "  Project initialized successfully!"

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -480,6 +480,10 @@ touch exports/html/.gitkeep
 mkdir -p docs/v1-original
 touch docs/v1-original/.gitkeep
 
+# Generate project README from IMDb template
+echo "Generating project README..."
+npx wtfb init-readme --title "$PROJECT_TITLE" --type "$PROJECT_TYPE" || echo -e "  ${YELLOW}README generation failed${NC}"
+
 echo ""
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}  Project initialized successfully!${NC}"


### PR DESCRIPTION
## Summary

- Adds `/init-readme` command for generating project README from IMDb-style template
- Integrates README generation into init workflow for all user paths
- Template README marker ensures safe overwrite behavior

## Test plan

- [ ] Clone template, run `npm run init`, verify README has project title/year/type
- [ ] Run `/start-project` via Claude, verify README generated
- [ ] Modify README, re-run init, verify it's not overwritten
- [ ] Run `/init-readme --force`, verify it regenerates

**Note**: Requires bybren-llc/wtfb-packages#1 for full functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)