### PR TITLE
fix(license): remove extra text for GitHub detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
 Copyright (c) 2026 J. Scott Graham (@cheddarfox) / Bybren LLC
-Words To Film By™
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-See NOTICE file for additional attribution requirements when using the
-WTFB™ multi-agent harness methodology.


### PR DESCRIPTION
## Summary

- Remove `Words To Film By™` line after copyright
- Remove `See NOTICE file...` reference at end

GitHub's Licensee tool requires LICENSE files to match known templates exactly. These extra lines were preventing MIT license detection.

## Test plan

- [ ] After merge, verify GitHub shows "MIT license" in repo sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)