### PR TITLE
chore(release): v1.5.2

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -38,6 +38,7 @@ codex
 harness
 subagent
 multiline
+agentic
 
 # Git/workflow terms
 husky

--- a/.wtfb/project.json
+++ b/.wtfb/project.json
@@ -2,10 +2,10 @@
   "$schema": "https://wtfb.io/schemas/project.v1.json",
   "projectType": "screenplay",
   "name": "wtfb-project",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "template": {
     "upstream": "https://github.com/bybren-llc/story-systems-template",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lastSync": null
   },
   "plugins": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Story Systems Template will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-01-20
+
+### Added
+
+- **`/init-readme` command**: Auto-populate project README from IMDb-style template
+
+### Changed
+
+- **Project rename**: "WTFB Projects Template" → "Story Systems Template"
+  - Updated README title, marketing config, Jekyll config
+  - Updated all user-facing documentation references
+  - Updated sync scripts and template relationship docs
+- **Repository references**: Updated marketplace name to `cheddarfox-claude-marketplace`
+- **License badge**: Moved to first position in README
+
+### Fixed
+
+- **SKILL_COMPLIANCE_CHECKLIST.md**: Fixed repo reference from `wtfb-safe-agentic-workflow` to `safe-agentic-workflow`
+
+---
+
 ## [1.4.0] - 2026-01-11
 
 ### Added


### PR DESCRIPTION
## Summary
- Bump version to 1.5.2 in project.json
- Add CHANGELOG entry documenting all changes since v1.5.1:
  - New `/init-readme` command
  - Project rename: "WTFB Projects Template" → "Story Systems Template"
  - Repository reference updates
  - License badge positioning fix
  - SKILL_COMPLIANCE_CHECKLIST repo reference fix
- Add 'agentic' to custom dictionary

## After Merge
Create and push tag:
```bash
git tag -a v1.5.2 -m "Release v1.5.2"
git push origin v1.5.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)