### PR TITLE
fix: sync package.json version to 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtfb-project",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "WTFB Creative Project",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Sync package.json version from 1.5.1 to 1.5.2 to match project.json and release tag

Missed during v1.5.2 release prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)