### PR TITLE
fix: replace WTFB branding with Story Systems in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,7 @@ Story Systems uses a **hub-spoke architecture** that's infinitely extensible:
        ▼               ▼               ▼
   ┌─────────┐    ┌─────────┐    ┌─────────┐
   │Community│    │  WTFB   │    │  Other  │
-  │ Plugins │    │(Example │    │Companies│
-  │ (Free)  │    │  Spoke) │    │ (Paid)  │
+  │  (Free) │    │(Example)│    │Companies│
   └─────────┘    └─────────┘    └─────────┘
 ```
 
@@ -319,7 +318,7 @@ Anyone can extend Story Systems. The architecture is open.
 
 1. Follow the same capability contract
 2. Add premium features (enhanced skills, workflows)
-3. Submit to the [Plugin Marketplace](https://github.com/bybren-llc/cheddarfox-claude-marketplace) (currently hosted at `bybren-llc/cheddarfox-claude-marketplace`)
+3. Submit to the [Plugin Marketplace](https://github.com/bybren-llc/cheddarfox-claude-marketplace)
 4. Earn revenue from your expertise
 
 ### Example Company Plugins: WTFB

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Story Systems uses a **hub-spoke architecture** that's infinitely extensible:
 - **Hub**: This template — complete 11-agent writing harness (free, OSS)
 - **Spokes**: Plugins that extend capabilities (free or paid)
 
+> **Story Systems is the open-source hub; company spokes (like WTFB) plug in to add brand-specific methodology and services on top of the baseline harness.**
+
 ```
               ┌──────────────────┐
               │  story-systems-  │
@@ -292,9 +294,9 @@ Story Systems uses a **hub-spoke architecture** that's infinitely extensible:
        │               │               │
        ▼               ▼               ▼
   ┌─────────┐    ┌─────────┐    ┌─────────┐
-  │  Your   │    │  Story  │    │Community│
-  │ Plugin  │    │ Systems │    │ Plugins │
-  │ (Free)  │    │ (Paid)  │    │ (Free)  │
+  │Community│    │  WTFB   │    │  Other  │
+  │ Plugins │    │(Example │    │Companies│
+  │ (Free)  │    │  Spoke) │    │ (Paid)  │
   └─────────┘    └─────────┘    └─────────┘
 ```
 
@@ -317,16 +319,16 @@ Anyone can extend Story Systems. The architecture is open.
 
 1. Follow the same capability contract
 2. Add premium features (enhanced skills, workflows)
-3. Submit to [Story Systems Marketplace](https://github.com/bybren-llc/cheddarfox-claude-marketplace) for review
+3. Submit to the [Plugin Marketplace](https://github.com/bybren-llc/cheddarfox-claude-marketplace) (currently hosted at `bybren-llc/cheddarfox-claude-marketplace`)
 4. Earn revenue from your expertise
 
-### Story Systems' Own Plugins (Leading by Example)
+### Example Company Plugins: WTFB
 
-We practice what we preach:
+WTFB plugins demonstrate how a company can extend the Story Systems hub with brand-specific workflows:
 
 | Plugin | What It Adds |
 |--------|--------------|
-| `wtfb-screenwriting` | Our proprietary Story Systems methodology, showrunner workflows |
+| `wtfb-screenwriting` | WTFB methodology, showrunner workflows |
 | `wtfb-novel-writing` | Extended narrative tools, chapter pacing |
 | `wtfb-film-production` | Call sheets, scheduling, budget tracking |
 
@@ -338,20 +340,26 @@ These demonstrate how to build premium enhancements that don't duplicate the bas
 
 ## Join the Story Systems Community
 
-```
-Use the Tools → Join Community → Take Courses → Get Published → Launch IRL
-      ↓              ↓              ↓              ↓              ↓
-  Write more    Get feedback   Master craft   We publish you   Film/TV
-  Write better  Find collaborators  Network    Promotes you    Distribution
-```
-
-We're building more than tools. We're building a path from idea to screen:
+The open-source hub has an active community:
 
 - **Use the tools** — Write more, write better
 - **Join the community** — Get feedback, find collaborators
-- **Take our courses** — Master the Story Systems methodology
-- **Get published** — Submit your work for Story Systems consideration
-- **Launch IRL** — From page to screen, we help make it real
+- **Contribute** — Submit plugins, report issues, improve the harness
+
+### WTFB Services (Company Spoke)
+
+[Words To Film By](https://wordstofilmby.com) offers additional services on top of the Story Systems hub:
+
+```
+Use the Tools → Join Community → Take Courses → Get Published → Launch IRL
+      ↓              ↓              ↓              ↓              ↓
+  Write more    Get feedback   Master craft   WTFB publishes   Film/TV
+  Write better  Find collaborators  Network    Promotes you    Distribution
+```
+
+- **Take courses** — Master the WTFB methodology
+- **Get published** — Submit your work for WTFB consideration
+- **Launch IRL** — From page to screen, WTFB helps make it real
 
 **Website**: [wordstofilmby.com](https://wordstofilmby.com)
 

--- a/README.md
+++ b/README.md
@@ -214,18 +214,18 @@ Your AI team is now active. All 11 agents, 24 skills, and 30 commands work out o
 
 ---
 
-## Why WTFB? (Competitive Analysis)
+## Why Story Systems? (Competitive Analysis)
 
-We did the research. Here's how WTFB compares to alternatives:
+We did the research. Here's how Story Systems compares to alternatives:
 
-| vs. Competition | WTFB Advantage |
+| vs. Competition | Story Systems Advantage |
 |-----------------|----------------|
 | **vs. Final Draft / Movie Magic** | They have no AI. We have 11 specialized agents. |
 | **vs. AI Writing Tools** | They're single AI. We're multi-agent with authority controls. |
 | **vs. CrewAI / AutoGen** | They're general-purpose. We have 24 craft skill modules. |
 | **vs. All of Them** | We're open source, extensible, and export to industry formats. |
 
-**Unique to WTFB:**
+**Unique to Story Systems:**
 
 - Tiered authority system (veto/gate powers)
 - Enterprise self-hosting with private workflows
@@ -233,7 +233,7 @@ We did the research. Here's how WTFB compares to alternatives:
 - Fountain format: open, portable, AI-friendly
 - VS Code Live Share for real-time collaboration
 
-> **Full Analysis:** [Competitive Analysis: WTFB Multi-Agent Harness](docs/COMPETITIVE-ANALYSIS-MULTI-AGENT-HARNESS.md)
+> **Full Analysis:** [Competitive Analysis: Story Systems Multi-Agent Harness](docs/COMPETITIVE-ANALYSIS-MULTI-AGENT-HARNESS.md)
 
 ---
 
@@ -271,9 +271,9 @@ We've already built a [software development harness](https://github.com/bybren-l
 
 ---
 
-## The WTFB Ecosystem
+## The Story Systems Ecosystem
 
-WTFB uses a **hub-spoke architecture** that's infinitely extensible:
+Story Systems uses a **hub-spoke architecture** that's infinitely extensible:
 
 - **Hub**: This template — complete 11-agent writing harness (free, OSS)
 - **Spokes**: Plugins that extend capabilities (free or paid)
@@ -292,8 +292,8 @@ WTFB uses a **hub-spoke architecture** that's infinitely extensible:
        │               │               │
        ▼               ▼               ▼
   ┌─────────┐    ┌─────────┐    ┌─────────┐
-  │  Your   │    │  WTFB   │    │Community│
-  │ Plugin  │    │ Premium │    │ Plugins │
+  │  Your   │    │  Story  │    │Community│
+  │ Plugin  │    │ Systems │    │ Plugins │
   │ (Free)  │    │ (Paid)  │    │ (Free)  │
   └─────────┘    └─────────┘    └─────────┘
 ```
@@ -304,7 +304,7 @@ WTFB uses a **hub-spoke architecture** that's infinitely extensible:
 
 ## Creating Your Own Plugins
 
-Anyone can extend WTFB. The architecture is open.
+Anyone can extend Story Systems. The architecture is open.
 
 ### Free Plugins (Contribute to Community)
 
@@ -317,16 +317,16 @@ Anyone can extend WTFB. The architecture is open.
 
 1. Follow the same capability contract
 2. Add premium features (enhanced skills, workflows)
-3. Submit to [WTFB Marketplace](https://github.com/bybren-llc/cheddarfox-claude-marketplace) for review
+3. Submit to [Story Systems Marketplace](https://github.com/bybren-llc/cheddarfox-claude-marketplace) for review
 4. Earn revenue from your expertise
 
-### WTFB's Own Plugins (Leading by Example)
+### Story Systems' Own Plugins (Leading by Example)
 
 We practice what we preach:
 
 | Plugin | What It Adds |
 |--------|--------------|
-| `wtfb-screenwriting` | Our proprietary WTFB methodology, showrunner workflows |
+| `wtfb-screenwriting` | Our proprietary Story Systems methodology, showrunner workflows |
 | `wtfb-novel-writing` | Extended narrative tools, chapter pacing |
 | `wtfb-film-production` | Call sheets, scheduling, budget tracking |
 
@@ -336,12 +336,12 @@ These demonstrate how to build premium enhancements that don't duplicate the bas
 
 ---
 
-## Join the WTFB Community
+## Join the Story Systems Community
 
 ```
 Use the Tools → Join Community → Take Courses → Get Published → Launch IRL
       ↓              ↓              ↓              ↓              ↓
-  Write more    Get feedback   Master craft   WTFB publishes   Film/TV
+  Write more    Get feedback   Master craft   We publish you   Film/TV
   Write better  Find collaborators  Network    Promotes you    Distribution
 ```
 
@@ -349,8 +349,8 @@ We're building more than tools. We're building a path from idea to screen:
 
 - **Use the tools** — Write more, write better
 - **Join the community** — Get feedback, find collaborators
-- **Take our courses** — Master the WTFB methodology
-- **Get published** — Submit your work for WTFB consideration
+- **Take our courses** — Master the Story Systems methodology
+- **Get published** — Submit your work for Story Systems consideration
 - **Launch IRL** — From page to screen, we help make it real
 
 **Website**: [wordstofilmby.com](https://wordstofilmby.com)


### PR DESCRIPTION
## Summary

- Replace all marketing/branding WTFB references with Story Systems
- "Why WTFB?" → "Why Story Systems?"
- "The WTFB Ecosystem" → "The Story Systems Ecosystem"
- "Join the WTFB Community" → "Join the Story Systems Community"
- "WTFB Marketplace" → "Story Systems Marketplace"
- "WTFB methodology" → "Story Systems methodology"
- Updated competitive analysis link text

**Technical references preserved** (correct behavior):
- `@wtfb/cli` package name
- `wtfb validate/export` CLI commands
- `wtfb-screenwriting` plugin names
- `WTFB-HARNESS-PAPER.md` filename

## Test plan

- [ ] Verify all visible branding now says "Story Systems"
- [ ] Confirm technical references (`@wtfb/cli`, `wtfb-*` plugins) unchanged
- [ ] Check markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Rebrand and docs refresh**
> 
> - Rename branding from `WTFB` to `Story Systems` across README (headings, tables, link text) including competitive analysis and ecosystem sections
> - Clarify hub–spoke model with `Story Systems` as the open-source hub and `WTFB` as an example company spoke
> - Expand community section and add “WTFB Services” subsection; adjust marketplace reference to “Plugin Marketplace” (URL unchanged)
> - Preserve technical references (e.g., `@wtfb/cli`, `wtfb-*` plugins, docs/files) unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b891d559b23ab02593f24be4e765f985915cd62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->