### PR TITLE
docs: update plugin section to emphasize open extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ claude
 
 Your AI team is now active. All 11 agents, 24 skills, and 30 commands work out of the box. The Story Architect ensures structure. The Dialogue Writer refines voices. The Script Supervisor catches formatting issues. They work together automatically.
 
-**Extensible by design.** Story Systems supports plugins installed through Claude Code's native `/plugin` workflow. Plugins can come from any source—GitHub repos, community marketplaces, or local paths.
+**Extensible by design.** Story Systems supports Claude Code's native `/plugin` workflow. Install from any supported source—GitHub repos, community marketplaces, or local paths.
 
 - **Community plugins** — Open-source extensions from the broader ecosystem
 - **Company spokes** — Premium workflows from sources like WTFB *(coming soon)*

--- a/README.md
+++ b/README.md
@@ -193,10 +193,12 @@ claude
 
 Your AI team is now active. All 11 agents, 24 skills, and 30 commands work out of the box. The Story Architect ensures structure. The Dialogue Writer refines voices. The Script Supervisor catches formatting issues. They work together automatically.
 
-**Optional: Install marketplace plugins** for enhanced workflows:
-```bash
-/plugin install wtfb-screenwriting@github.com/bybren-llc/cheddarfox-claude-marketplace/plugins/screenwriting
-```
+**Extensible by design.** Story Systems supports plugins installed through Claude Code's native `/plugin` workflow. Plugins can come from any source—GitHub repos, community marketplaces, or local paths.
+
+- **Community plugins** — Open-source extensions from the broader ecosystem
+- **Company spokes** — Premium workflows from sources like WTFB *(coming soon)*
+
+When installing plugins, Claude Code uses a permission prompt model—review prompts when plugins request actions. See [Claude Code Plugins](https://claude.com/blog/claude-code-plugins) for installation details and marketplace examples.
 
 ---
 


### PR DESCRIPTION
## Summary

Replace the specific plugin install command with messaging that emphasizes the open ecosystem:

### Before
```markdown
**Optional: Install marketplace plugins** for enhanced workflows:
```bash
/plugin install wtfb-screenwriting@github.com/bybren-llc/...
```
```

### After
```markdown
**Extensible by design.** Story Systems supports plugins installed through 
Claude Code's native `/plugin` workflow. Plugins can come from any source—
GitHub repos, community marketplaces, or local paths.

- **Community plugins** — Open-source extensions from the broader ecosystem
- **Company spokes** — Premium workflows from sources like WTFB *(coming soon)*

When installing plugins, Claude Code uses a permission prompt model—review 
prompts when plugins request actions. See [Claude Code Plugins](...) for 
installation details and marketplace examples.
```

### Key Changes
- Removes specific plugin install command (was pointing to private repo)
- Emphasizes open ecosystem (plugins from any source)
- Mentions community plugins and company spokes (WTFB coming soon)
- Adds permission prompt model safety note
- Links to official [Claude Code Plugins](https://claude.com/blog/claude-code-plugins) blog

## Test plan
- [ ] Verify link to Claude Code Plugins blog works
- [ ] Confirm no references to private repos
- [ ] Review messaging aligns with hub/spoke narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts README plugin guidance from a specific install example to open, source-agnostic extensibility via Claude Code's `
> /plugin` workflow.
> 
> - Removes private repo install snippet in favor of generic plugin installation guidance
> - Adds notes on sourcing plugins from GitHub, marketplaces, or local paths
> - Introduces categories: **Community plugins** and **Company spokes** *(WTFB coming soon)*
> - Mentions permission prompt model and links to **Claude Code Plugins** blog for details
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10814d762405de38af03c1a835a4363fb8b1d790. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->